### PR TITLE
Basic code for dynamic width markings

### DIFF
--- a/simnode/generator.py
+++ b/simnode/generator.py
@@ -21,7 +21,6 @@ class ScenarioBuilder:
         self.participants = participants
         self.time_of_day = time_of_day
 
-    # TODO Added markings_smoothing for easier adjustment and experimenting, is this ok?
     @static_vars(line_width=0.15, num_nodes=100, smoothness=0, markings_smoothing=0.13)
     def add_roads_to_scenario(self, scenario: Scenario) -> None:
         from beamngpy import Road

--- a/simnode/generator.py
+++ b/simnode/generator.py
@@ -71,6 +71,7 @@ class ScenarioBuilder:
             # FIXME Recognize changing widths --- mostly done
             road_width = unique_nodes[0].width
             if road.markings:
+                # could theoretically be removed or integrated in _calculate_parallel_coords_list()
                 def _calculate_parallel_coords(offset: float, line_width: float) \
                         -> Optional[List[Tuple[float, float, float, float]]]:
                     original_line = LineString(zip(new_x_vals, new_y_vals))
@@ -134,11 +135,13 @@ class ScenarioBuilder:
                     offset_sub_lines = ()
                     previous_p = 1
                     i = 0
+                    # split road into multiple pieces
                     for p in cutting_points:
                         # cython int32 to int
                         p = int(p)
                         if p > 0:
                             try:
+                                # calculate parallel offset for each road piece
                                 road_lnstr = LineString(original_line.coords[previous_p: p]).parallel_offset(offset[i])
                                 if offset_sub_lines.__len__() == 0:
                                     offset_sub_lines = road_lnstr.coords.xy

--- a/simnode/generator.py
+++ b/simnode/generator.py
@@ -7,6 +7,11 @@ from lxml.etree import _ElementTree, _Element
 
 _logger = getLogger("DriveBuild.SimNode.Generator")
 
+# TODO only needed for parameter types, does this make sense? Or should i convert array to list --> unneccessary
+#  performance decrease
+from array import array
+from numpy import ndarray
+
 
 class ScenarioBuilder:
     from beamngpy import Scenario
@@ -21,8 +26,8 @@ class ScenarioBuilder:
         self.participants = participants
         self.time_of_day = time_of_day
 
-    # TODO should num_nodes be fixed?
-    @static_vars(line_width=0.15, num_nodes=100, smoothness=0)
+    # TODO Added markings_smoothing for easier adjustment and experimenting, is this ok?
+    @static_vars(line_width=0.15, num_nodes=100, smoothness=0, markings_smoothing=0.13)
     def add_roads_to_scenario(self, scenario: Scenario) -> None:
         from beamngpy import Road
         from shapely.geometry import LineString
@@ -68,7 +73,10 @@ class ScenarioBuilder:
             main_nodes = list(zip(new_x_vals, new_y_vals, z_vals, new_width_vals))
             main_road.nodes.extend(main_nodes)
             scenario.add_road(main_road)
-            # FIXME Recognize changing widths --- mostly done
+            # FIXME Recognize changing widths --- Basic drawing works for all the roads I have testes so far,
+            #  however strong width changes cause stair stepping, this can be countered by a smoothing parameter,
+            #  but this itself can introduce low poly lines and inaccuracies. Better post processing or a dynamic
+            #  sampling rate may fix this.
             road_width = unique_nodes[0].width
             if road.markings:
                 # could theoretically be removed or integrated in _calculate_parallel_coords_list()
@@ -87,7 +95,7 @@ class ScenarioBuilder:
                     marking_widths = repeat(line_width, num_coords)
                     return list(zip(coords[0], coords[1], z_vals, marking_widths))
 
-                def _calculate_offset_list(relative_offset: float, absolute_offset: float = 0,
+                def _calculate_offset_list(relative_offset: float, absolute_offset: float,
                                            output_number_of_points: int = self.add_roads_to_scenario.num_nodes//3) \
                                             -> List[float]:
                     """ calculates a list of relative offsets to the road centre
@@ -109,11 +117,70 @@ class ScenarioBuilder:
                     output_vals = list(map(lambda i: new_width_vals[i]*relative_offset + absolute_offset, cutting_points))
                     return output_vals
 
-                # TODO Should this method coexist to _calculate_parallel_coords(offset: float, line_width: float)? Or
-                #  should the older method be integrated? (by simulating overloading using type()?)
-                #  The functionality is basically the same, except it works for changing widths and needs a list as
-                #  input. I tried to make the operation similar.
-                def _calculate_parallel_coords_list(offset: list, line_width: float) \
+                def _calculate_parallel_pieces(offset: List[float], original_line: LineString, cutting_points: ndarray)\
+                                                -> Tuple[array, array]:
+                    # TODO how to specify the type of an array? Should be float...
+                    """ This method will calculate offsets for smaller pieces of road.
+
+                    :param offset: list of width offsets, must be smaller than num_nodes//2, should be equidistant
+                    :param original_line: LineString of baseline road coordinates
+                    :param cutting_points: array of points at which the road is split into pieces
+                    :return: Returns a tuple of float arrays for x and y values
+                    """
+                    from shapely.errors import TopologicalError
+
+                    offset_sub_lines = ()
+                    previous_p = 1
+                    i = 0
+                    for p in cutting_points:
+                        # cython int32 to int
+                        p = int(p)
+                        if p > 0:
+                            try:
+                                piece_coords = original_line.coords[previous_p: p]
+                                if piece_coords.__len__() > 1:
+                                    road_lnstr = LineString(piece_coords).parallel_offset(offset[i])
+                                    if offset_sub_lines.__len__() == 0:
+                                        offset_sub_lines = road_lnstr.coords.xy
+                                        # shapely reverses if the offset is positive
+                                        if offset[i] > 0:
+                                            offset_sub_lines[0].reverse()
+                                            offset_sub_lines[1].reverse()
+                                    else:
+                                        line_str_0 = (road_lnstr.coords.xy)[0]
+                                        line_str_1 = (road_lnstr.coords.xy)[1]
+                                        # shapely reverses if the offset is positive
+                                        if offset[i] > 0:
+                                            line_str_0.reverse()
+                                            line_str_1.reverse()
+                                        offset_sub_lines[0].extend(line_str_0)
+                                        offset_sub_lines[1].extend(line_str_1)
+                            # Does the program continue if there is no return None?
+                            except ValueError:
+                                _logger.exception("Some portions of the LineString are empty")
+                            except TopologicalError:
+                                _logger.exception("Shapely cannot create a valid polygon")
+                        previous_p = p
+                        i += 1
+                    return offset_sub_lines
+
+                def _smoothen_line(offset_sub_lines: Tuple[array, array]) -> Tuple[array, array]:
+                    """ Smoothes a line by the usage of LineString.simplify()
+
+                    :param offset_sub_lines: Tuple of float arrays for x and y values
+                    :return: Smoothed tuple of float arrays for x and y values
+                    """
+                    # TODO same as above: type of array
+                    # softens stair stepping if the road width changes fast
+                    # TODO tolerance parameter may need to be adjusted
+                    # could be expensive --> replace with #coords = offset_sub_lines
+                    point_list = list(map(lambda i: (offset_sub_lines[0][i], offset_sub_lines[1][i]),
+                                          range(0, offset_sub_lines[0].__len__() - 1)))
+                    lstr = LineString(point_list)
+                    lstr = lstr.simplify(tolerance=self.add_roads_to_scenario.markings_smoothing)
+                    return lstr.coords.xy
+
+                def _calculate_parallel_coords_list(offset: List[float], line_width: float) \
                         -> Optional[List[Tuple[float, float, float, float]]]:
                     """ calculates parallel coordinates of a road
 
@@ -126,65 +193,15 @@ class ScenarioBuilder:
                         "there have to be less than half offset points of num_node for shapely LineStrings to work"
 
                     original_line = LineString(zip(new_x_vals, new_y_vals))
-                    # num_points = original_line.length # seems to sometimes be trimmed to a bit more than 100?
                     num_points = self.add_roads_to_scenario.num_nodes
                     cutting_points = linspace(0, num_points-1, dtype=int, num=min(num_points, offset.__len__()))
                     # extend the last point just a bit to get all nodes
                     cutting_points[-1] = cutting_points[-1] + cutting_points [-1] - cutting_points[-2]
 
-                    offset_sub_lines = ()
-                    previous_p = 1
-                    i = 0
-                    # split road into multiple pieces
-                    for p in cutting_points:
-                        # cython int32 to int
-                        p = int(p)
-                        if p > 0:
-                            try:
-                                # calculate parallel offset for each road piece
-                                road_lnstr = LineString(original_line.coords[previous_p: p]).parallel_offset(offset[i])
-                                if offset_sub_lines.__len__() == 0:
-                                    offset_sub_lines = road_lnstr.coords.xy
-                                    # needs to be reversed for positive offset (why?)
-                                    if offset[i] > 0:
-                                        offset_sub_lines[0].reverse()
-                                        offset_sub_lines[1].reverse()
-                                else:
-                                    # try except not pretty, but problems with empty line string segments solved
-                                    try:
-                                        line_str_0 = (road_lnstr.coords.xy)[0]
-                                        line_str_1 = (road_lnstr.coords.xy)[1]
-                                        # needs to be reversed for positive offset (why?)
-                                        if offset[i] > 0:
-                                            line_str_0.reverse()
-                                            line_str_1.reverse()
-                                        offset_sub_lines[0].extend(line_str_0)
-                                        offset_sub_lines[1].extend(line_str_1)
-                                    except Exception:
-                                        # this break fixes failing calculation, if a line segment is empty, but
-                                        # it is really ugly
-                                        break
-                            except (NotImplementedError, Exception):  # FIXME Where is TopologyException
-                                _logger.exception("Creating an offset line for lane markings failed")
-                                return None
-                        previous_p = p
-                        i += 1
-                    if offset_sub_lines.__len__() > 1:
-                        # softens stair stepping if the road width changes fast
-                        # TODO tolerance parameter may need to be adjusted
-                        # could be expensive --> replace with #coords = offset_sub_lines
-                        point_list = list(map(lambda i: (offset_sub_lines[0][i], offset_sub_lines[1][i]),
-                                              range(0, offset_sub_lines[0].__len__()-1)))
-                        lstr = LineString(point_list)
-                        lstr = lstr.simplify(tolerance=0.13)
-                        coords = lstr.coords.xy
+                    offset_sub_lines = _calculate_parallel_pieces(offset, original_line, cutting_points)
 
-                        # for plotting the generated road, useful for debugging
-                        '''import matplotlib.pyplot as plt
-                        plt.plot(offset_sub_lines[0], offset_sub_lines[1])
-                        plt.ylabel("first offset: " + str(offset[0]))
-                        plt.show()
-                        '''
+                    if offset_sub_lines.__len__() > 1:
+                        coords = _smoothen_line(offset_sub_lines)
                     # NOTE The parallel LineString may have a different number of points than initially given
                     num_coords = len(coords[0])
                     z_vals = repeat(0.01, num_coords)
@@ -197,7 +214,7 @@ class ScenarioBuilder:
                 side_line_offset = 1.5 * self.add_roads_to_scenario.line_width
                 left_side_line = Road('line_white', rid=road.rid + "_left_line")
                 offset_list_line_left = _calculate_offset_list(relative_offset=-0.5,
-                                                                absolute_offset=side_line_offset)
+                                                                absolute_offset=side_line_offset*1.5)
                 left_side_line_nodes = _calculate_parallel_coords_list(offset_list_line_left,
                                                                         self.add_roads_to_scenario.line_width)
                 if left_side_line_nodes:
@@ -216,7 +233,6 @@ class ScenarioBuilder:
                     _logger.warning("Could not create right side line")
 
                 # Draw line separating left from right lanes
-                # FIXME rightLanes cannot be 0, is this by design?
                 if road.left_lanes > 0 and road.right_lanes > 0:
                     divider_rel_off = -0.5 + road.left_lanes/(road.left_lanes+road.right_lanes)
                     offset_list_divider = _calculate_offset_list(relative_offset=divider_rel_off,
@@ -243,7 +259,7 @@ class ScenarioBuilder:
                     # '.' have to be removed from the name, else there are prefab parsing errors for positive offsets
                     lane_separation_line = Road('line_dashed_short',
                                                 rid=road.rid + "_separator_" + str(offs).replace('.', ''))
-                    offs_list = _calculate_offset_list(offs)
+                    offs_list = _calculate_offset_list(offs, 0)
                     lane_separation_line_nodes \
                         = _calculate_parallel_coords_list(offs_list, self.add_roads_to_scenario.line_width)
 

--- a/simnode/generator.py
+++ b/simnode/generator.py
@@ -117,135 +117,6 @@ class ScenarioBuilder:
                     output_vals = list(map(lambda i: new_width_vals[i]*relative_offset + absolute_offset, cutting_points))
                     return output_vals
 
-                '''
-                def _calculate_parallel_pieces(offset: List[float], original_line: LineString, cutting_points: ndarray)\
-                                                -> Tuple[array, array]:
-                    # TODO how to specify the type of an array? Should be float...
-                    """ This method will calculate offsets for smaller pieces of road.
-
-                    :param offset: list of width offsets, must be smaller than num_nodes//2, should be equidistant
-                    :param original_line: LineString of baseline road coordinates
-                    :param cutting_points: array of points at which the road is split into pieces
-                    :return: Returns a tuple of float arrays for x and y values
-                    """
-                    from shapely.errors import TopologicalError
-
-                    offset_sub_lines = ()
-                    previous_p = 1
-                    i = 0
-                    for p in cutting_points:
-                        # cython int32 to int
-                        p = int(p)
-                        if p > 0:
-                            try:
-                                piece_coords = original_line.coords[previous_p: p]
-                                if p == 3:
-                                    print("piece from ", previous_p, " to ", p, " : ", piece_coords)
-                                if piece_coords.__len__() > 1:
-                                    #print("first p at which linestr isnt null: ", p)
-                                    road_lnstr = LineString(piece_coords).parallel_offset(offset[i])
-                                    if offset_sub_lines.__len__() == 0:
-                                        offset_sub_lines = road_lnstr.coords.xy
-                                        # shapely reverses if the offset is positive
-                                        if offset[i] > 0:
-                                            offset_sub_lines[0].reverse()
-                                            offset_sub_lines[1].reverse()
-                                    else:
-                                        line_str_0 = (road_lnstr.coords.xy)[0]
-                                        line_str_1 = (road_lnstr.coords.xy)[1]
-                                        # shapely reverses if the offset is positive
-                                        if offset[i] > 0:
-                                            line_str_0.reverse()
-                                            line_str_1.reverse()
-                                        offset_sub_lines[0].extend(line_str_0)
-                                        offset_sub_lines[1].extend(line_str_1)
-                            # Does the program continue if there is no return None?
-                            except ValueError:
-                                _logger.exception("Some portions of the LineString are empty")
-                            except TopologicalError:
-                                _logger.exception("Shapely cannot create a valid polygon")
-                        previous_p = p
-                        i += 1
-                    return offset_sub_lines
-
-                '''
-
-                '''
-                                def _calculate_parallel_pieces(offset: List[float], original_line: LineString, cutting_points: List[int]) \
-                        -> Tuple[array, array]:
-                    # TODO how to specify the type of an array? Should be float...
-                    """ This method will calculate offsets for smaller pieces of road.
-
-                    :param offset: list of width offsets, must be smaller than num_nodes//2, should be equidistant
-                    :param original_line: LineString of baseline road coordinates
-                    :param cutting_points: array of points at which the road is split into pieces
-                    :return: Returns a tuple of float arrays for x and y values
-                    """
-                    from shapely.errors import TopologicalError
-
-                    assert not original_line.is_empty, "Original line has to contain a road"
-                    assert cutting_points.__len__() < self.add_roads_to_scenario.num_nodes//2, "too many cutting points"
-
-                    cutting_points.remove(0)
-                    offset_sub_lines = _initial_parallel_piece(first_offset=offset[0], original_line=original_line,
-                                                      first_cutting_point=cutting_points[0])
-
-                    previous_p = cutting_points[0]
-                    cutting_points.pop(0)
-                    print("cutting_points: ", cutting_points)
-
-                    further_sublines = _further_parallel_pieces(offset=offset, original_line=original_line,
-                                                                cutting_points=cutting_points,
-                                                                offset_sub_lines=offset_sub_lines)
-                    offset_sub_lines[0].append(further_sublines[0])
-                    offset_sub_lines[1].append(further_sublines[1])
-                    return offset_sub_lines
-
-                def _initial_parallel_piece(first_offset: float, original_line: LineString, first_cutting_point: int)\
-                        -> Tuple[List[float], List[float]]:
-                    from shapely.errors import TopologicalError
-                    try:
-                        piece_coords = original_line.coords[0: first_cutting_point]
-                        road_lnstr = LineString(piece_coords).parallel_offset(first_offset)
-                        offset_sub_lines = road_lnstr.coords.xy
-                        # shapely reverses if the offset is positive
-                        if first_offset > 0:
-                            offset_sub_lines[0].reverse()
-                            offset_sub_lines[1].reverse()
-                        print("type(offset_sub_lines): ", type(offset_sub_lines))
-                        return offset_sub_lines
-                    except ValueError:
-                        _logger.exception("Some portions of the LineString are empty")
-                    except TopologicalError:
-                        _logger.exception("Shapely cannot create a valid polygon")
-
-                def _further_parallel_pieces(offset: List[float], original_line: LineString, cutting_points: List[int], offset_sub_lines: Tuple[List[float], List[float]]) \
-                        -> Tuple[List[float], List[float]]:
-                    from shapely.errors import TopologicalError
-                    i = 1
-                    for p in cutting_points:
-                        if p > 0:
-                            try:
-                                piece_coords = original_line.coords[previous_p: p]
-                                if piece_coords.__len__() > 1:
-                                    road_lnstr = LineString(piece_coords).parallel_offset(offset[i])
-                                    line_str_0 = (road_lnstr.coords.xy)[0]
-                                    line_str_1 = (road_lnstr.coords.xy)[1]
-                                    # shapely reverses if the offset is positive
-                                    if offset[i] > 0:
-                                        line_str_0.reverse()
-                                        line_str_1.reverse()
-                                    offset_sub_lines[0].extend(line_str_0)
-                                    offset_sub_lines[1].extend(line_str_1)
-                            # Does the program continue if there is no return None?
-                            except ValueError:
-                                _logger.exception("Some portions of the LineString are empty")
-                            except TopologicalError:
-                                _logger.exception("Shapely cannot create a valid polygon")
-                        previous_p = p
-                        i += 1
-                    return offset_sub_lines
-                '''
                 def _calculate_parallel_pieces(offset: List[float], original_line: LineString,
                                                cutting_points: List[int]) -> Tuple[List[float], List[float]]:
                     """ This method will calculate offsets for smaller pieces of road.
@@ -338,15 +209,11 @@ class ScenarioBuilder:
 
                 def _smoothen_line(offset_sub_lines_x: List[float], offset_sub_lines_y: List[float]) \
                         -> Tuple[List[float], List[float]]:
-                    """ Smoothes a line by the usage of LineString.simplify()
+                    """ Smoothens a line by the usage of LineString.simplify() and reduces stair stepping
 
                     :param offset_sub_lines: Tuple of float lists for x and y values
                     :return: Smoothed tuple of float lists for x and y values
                     """
-                    # TODO same as above: type of array
-                    # softens stair stepping if the road width changes fast
-                    # TODO tolerance parameter may need to be adjusted
-                    # could be expensive --> replace with #coords = offset_sub_lines
                     point_list = list(map(lambda i: (offset_sub_lines_x[i], offset_sub_lines_y[i]),
                                           range(0, offset_sub_lines_x.__len__() - 1)))
                     lstr = LineString(point_list)

--- a/simnode/generator.py
+++ b/simnode/generator.py
@@ -79,7 +79,6 @@ class ScenarioBuilder:
             #  sampling rate may fix this.
             road_width = unique_nodes[0].width
             if road.markings:
-                # could theoretically be removed or integrated in _calculate_parallel_coords_list()
                 def _calculate_parallel_coords(offset: float, line_width: float) \
                         -> Optional[List[Tuple[float, float, float, float]]]:
                     original_line = LineString(zip(new_x_vals, new_y_vals))

--- a/simnode/generator.py
+++ b/simnode/generator.py
@@ -117,9 +117,9 @@ class ScenarioBuilder:
                 def _calculate_parallel_pieces(offset: List[float], cutting_points: List[int]) \
                         -> Tuple[List[float], List[float]]:
                     """ This method will calculate offsets for smaller pieces of road.
+                    uses new_x_vals and new_y_vals as baseline road
 
                     :param offset: list of width offsets, must be smaller than num_nodes//2, should be equidistant
-                    :param original_line: LineString of baseline road coordinates
                     :param cutting_points: list of points at which the road is split into pieces
                     :return: Returns a tuple of float lists for x and y values
                     """
@@ -179,7 +179,7 @@ class ScenarioBuilder:
                     :return: Smoothed tuple of float lists for x and y values
                     """
                     assert offset_sub_lines_x.__len__() > 1 and offset_sub_lines_y.__len__() > 1, \
-                        "cannot smooth a empty line or point"
+                        "cannot smooth an empty line or a point"
 
                     point_list = list(map(lambda i: (offset_sub_lines_x[i], offset_sub_lines_y[i]),
                                           range(0, offset_sub_lines_x.__len__() - 1)))


### PR DESCRIPTION
Code for drawing lane markings on roads with dynamic width. The idea is that multiple parallel road pieces are calculated, the offsets are sampled from new_width_vals. 
Some parts may be removed or changed. Additional or more advanced smoothing may make sense, there could be a detection system if and where the width changes. New parts are described in comments. Smoothing can be adjusted via output_number_of_points parameter in _calculate_offset_list() and via lstr.simplify(tolerance=0.13) in line 179.